### PR TITLE
#1 Fix for max version replaced.

### DIFF
--- a/NuspecAutoUpdate.ps1
+++ b/NuspecAutoUpdate.ps1
@@ -69,7 +69,7 @@ foreach($targetFrameworkGroup in $nuspecXml.package.metadata.dependencies.group)
             $oldVersion = $($dependencyEntry.version);
 
             #Notice: the fullNewVersion include "[ ] ( ) ," chars that doesn't exist in the package config file.
-            $fullNewVersion = $oldVersion -replace $versionRegex, $versionFromConfigFile;
+            $fullNewVersion = $versionRegex.replace($oldVersion, $versionFromConfigFile, 1);
             if($dependencyEntry.version -ne $fullNewVersion)
             {
                 $dependencyEntry.version = $fullNewVersion;


### PR DESCRIPTION
Fixes #1 

With this fix, now when a dependency has min max version defined, it will replace only the min version. So you can manually manage max version according to what your NuGet package supports.